### PR TITLE
Fix callback reuse when not refreshing

### DIFF
--- a/lib/node-ipmi.js
+++ b/lib/node-ipmi.js
@@ -58,7 +58,7 @@ Connect.prototype.getSensors = function(cb, refreshdata) {
 
   if(this.sensors!==null && !refreshdata) {
     console.log("reuse");
-    cb(null, this.sensors);
+    return cb(null, this.sensors);
   }
 
   Sensors.getSensors(this.cmdOptions, callback);


### PR DESCRIPTION
When getSensors is called after data is already available (i.e., a second time), with !refreshdata, it will call the callback twice: with the old data, and new data. This double-callback causes issues when integrating with other code expecting callbacks to be called only once (Node.js convention):

http://joseoncode.com/2013/12/27/case-of-double-callbacks/
http://stackoverflow.com/questions/16764160/node-js-callback-called-twice
etc.

or in my case, from https://github.com/KhaosT/HAP-NodeJS/blob/master/lib/util/once.js:

``` javascript
      throw new Error("This callback function has already been called by someone else; it can only be called one time.");
```

took a while to track down node-ipmi was calling it twice and not my code. Not sure of a proper fix but returning with the cached data is one possible fix for only calling it once (and the caller can always pass refreshdata true to get the latest data).
